### PR TITLE
fix: Pulsar set Pulsar data inside flatpak sandbox

### DIFF
--- a/dev.pulsar_edit.Pulsar.json
+++ b/dev.pulsar_edit.Pulsar.json
@@ -15,15 +15,12 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=dri",
-        "--filesystem=home",
-        "--filesystem=/media",
-        "--filesystem=/run/media",
+        "--filesystem=host",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.gtk.vfs.*",
         "--env=ELECTRON_TRASH=gio",
-        "--env=TMPDIR=/var/tmp",
-        "--persist=.pulsar"
+        "--env=TMPDIR=/var/tmp"
     ],
     "modules": [
         {
@@ -59,6 +56,7 @@
                     "dest-filename": "pulsar.sh",
                     "commands": [
                         "#!/bin/sh\n",
+                        "export ATOM_HOME=\"$XDG_DATA_HOME\"",
                         "/app/bin/zypak-wrapper.sh /app/Pulsar/pulsar --in-process-gpu --executed-from=\"$(pwd)\" --pid=$$ \"$@\""
                     ]
                 }


### PR DESCRIPTION
Another approach to sandbox Pulsar's app data. Usually `XDG_DATA_HOME` is set to `$HOME/.local/share` but instead flatpak sets it into it's data directory.