### PR TITLE
fix: remove temporary webview cache after exit

### DIFF
--- a/dev.pulsar_edit.Pulsar.json
+++ b/dev.pulsar_edit.Pulsar.json
@@ -78,7 +78,8 @@
                     "dest-filename": "pulsar",
                     "commands": [
                         "export ATOM_HOME=\"$XDG_DATA_HOME\"",
-                        "/app/bin/zypak-wrapper.sh /app/Pulsar/pulsar --in-process-gpu --executed-from=\"$(pwd)\" --pid=$$ \"$@\""
+                        "/app/bin/zypak-wrapper.sh /app/Pulsar/pulsar --in-process-gpu --executed-from=\"$(pwd)\" --pid=$$ \"$@\"",
+                        "rm -f $TMPDIR/.org.chromium.Chromium.*"
                     ]
                 },
                 {


### PR DESCRIPTION
It's deleted in regular Pulsar unlike the Flatpak creating a lot of files over time.