### PR TITLE
Fix: include new version in metadata

### DIFF
--- a/dev.pulsar_edit.Pulsar.metainfo.xml
+++ b/dev.pulsar_edit.Pulsar.metainfo.xml
@@ -37,6 +37,7 @@
     <keyword>atom</keyword>
   </keywords>
   <releases>
+    <release version="1.118.0" date="2024-06-16"/>
     <release version="1.117.0" date="2024-05-16"/>
     <release version="1.116.0" date="2024-04-15"/>
     <release version="1.115.0" date="2024-03-23"/>


### PR DESCRIPTION
The Flathub bot unfortunately forgot to add it.