### PR TITLE
fix: fix trash & update permissions

### DIFF
--- a/dev.pulsar_edit.Pulsar.json
+++ b/dev.pulsar_edit.Pulsar.json
@@ -15,7 +15,6 @@
         "--socket=ssh-auth",
         "--share=network",
         "--device=dri",
-        "--filesystem=home",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.gtk.vfs.*",
         "--env=ELECTRON_TRASH=gvfs-trash",

--- a/dev.pulsar_edit.Pulsar.json
+++ b/dev.pulsar_edit.Pulsar.json
@@ -10,17 +10,18 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
-        "--socket=pulseaudio",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=ssh-auth",
         "--share=network",
         "--device=dri",
-        "--filesystem=host",
-        "--talk-name=org.freedesktop.Notifications",
+        "--filesystem=home",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.gtk.vfs.*",
-        "--env=ELECTRON_TRASH=gio",
-        "--env=TMPDIR=/var/tmp"
+        "--env=ELECTRON_TRASH=gvfs-trash",
+        "--env=TMPDIR=/var/tmp",
+        "--env=ELECTRON_OZONE_PLATFORM_HINT=auto",
+        "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
     ],
     "modules": [
         {
@@ -89,14 +90,6 @@
                         "export ATOM_HOME=\"$XDG_DATA_HOME\"",
                         "/app/Pulsar/resources/app/ppm/bin/ppm --in-process-gpu --executed-from=\"$(pwd)\" --pid=$$ \"$@\""
                     ]
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "apm",
-                    "commands": [
-                        "export ATOM_HOME=\"$XDG_DATA_HOME\"",
-                        "/app/Pulsar/resources/app/ppm/bin/apm --in-process-gpu --executed-from=\"$(pwd)\" --pid=$$ \"$@\""
-                    ]
                 }
             ],
             "name": "pulsar",
@@ -112,8 +105,7 @@
                 "desktop-file-edit --set-key=Icon --set-value='dev.pulsar_edit.Pulsar' /app/share/applications/pulsar.desktop",
                 "install pulsar /app/bin",
                 "install ppm /app/bin",
-                "install apm /app/bin",
-                "chmod +x \"/app/bin/pulsar\" \"/app/bin/ppm\" \"/app/bin/apm\"",
+                "chmod +x \"/app/bin/pulsar\" \"/app/bin/ppm\"",
                 "mkdir -p /app/share/icons/hicolor/scalable/apps/",
                 "install -Dm644 dev.pulsar_edit.Pulsar.svg /app/share/icons/hicolor/scalable/apps/",
                 "install -Dm644 dev.pulsar_edit.Pulsar.metainfo.xml /app/share/metainfo/dev.pulsar_edit.Pulsar.metainfo.xml"


### PR DESCRIPTION
Thanks to the help from #75 and #76, the Flatpak manifest is updated to fix Pulsar's trash and some general maintenance tasks since `apm` is not in Pulsar anymore. There is also the inclusion of running Pulsar natively on Wayland. If this change is broken, then this will definitely get reverted.